### PR TITLE
feat(#4719): goldmark md→HTML renderer in golib/Markdown

### DIFF
--- a/Markdown/renderer.go
+++ b/Markdown/renderer.go
@@ -1,0 +1,72 @@
+// Package markdown provides a thin goldmark-based Markdown → HTML renderer for
+// use across DigiStratum Go applications.
+//
+// The primary entry-point is [Render], which converts a Markdown string to a
+// [html/template.HTML] value.  Because [html/template.HTML] is treated as
+// pre-sanitised by Go's html/template engine, the rendered output is inserted
+// verbatim into templates — no double-escaping occurs.
+//
+// GFM extensions enabled by default:
+//   - Tables
+//   - Strikethrough
+//   - Autolinks
+//   - Task lists
+//
+// Safe HTML mode is ON: raw HTML blocks inside the Markdown source are
+// stripped, protecting downstream templates from injection.
+package markdown
+
+import (
+	"bytes"
+	"html/template"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/extension"
+	"github.com/yuin/goldmark/parser"
+	gmHTML "github.com/yuin/goldmark/renderer/html"
+)
+
+// defaultParser is a package-level goldmark instance with sensible defaults
+// for DigiStratum agentic output patterns.  It is safe for concurrent use.
+var defaultParser = goldmark.New(
+	goldmark.WithExtensions(
+		extension.GFM, // Tables, Strikethrough, Autolinks, TaskList
+	),
+	goldmark.WithParserOptions(
+		parser.WithAutoHeadingID(), // stable heading anchors for in-page links
+	),
+	goldmark.WithRendererOptions(
+		gmHTML.WithHardWraps(), // treat single newlines as <br>
+		gmHTML.WithXHTML(),     // well-formed XHTML output (self-closing tags)
+	),
+)
+
+// Render converts md (a Markdown string) into HTML and returns it as a
+// [html/template.HTML] value, which is safe to use directly in Go templates
+// without further escaping.
+//
+// The renderer uses GitHub Flavoured Markdown extensions (tables, strikethrough,
+// autolinks, task lists) and strips any raw HTML present in the source so that
+// agentic output cannot inject markup.
+//
+// Example:
+//
+//	html, err := markdown.Render("## Hello\n\n- item one\n- item two")
+//	// html == template.HTML("<h2 id=\"hello\">Hello</h2>\n<ul>\n<li>item one</li>\n…")
+func Render(md string) (template.HTML, error) {
+	var buf bytes.Buffer
+	if err := defaultParser.Convert([]byte(md), &buf); err != nil {
+		return "", err
+	}
+	return template.HTML(buf.String()), nil //nolint:gosec // caller-controlled markdown; raw HTML stripped by goldmark safe mode
+}
+
+// MustRender is like [Render] but panics on error.  Use in init() or tests
+// where the input is a compile-time constant.
+func MustRender(md string) template.HTML {
+	html, err := Render(md)
+	if err != nil {
+		panic("markdown.MustRender: " + err.Error())
+	}
+	return html
+}

--- a/Markdown/renderer_test.go
+++ b/Markdown/renderer_test.go
@@ -1,0 +1,153 @@
+package markdown_test
+
+import (
+	"strings"
+	"testing"
+
+	markdown "github.com/DigiStratum/GoLib/Markdown"
+)
+
+// TestRender_TableDriven covers the common agentic output patterns:
+// headers, links, code blocks, lists, and tables.
+func TestRender_TableDriven(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		contains []string // substrings that must appear in output
+		notContains []string // raw markdown artifacts that must NOT appear in output
+	}{
+		{
+			name:  "h1 header",
+			input: "# Hello World",
+			// goldmark WithAutoHeadingID adds an id attribute; match on tag + content
+			contains: []string{"<h1 ", ">Hello World</h1>"},
+		},
+		{
+			name:     "h2 header",
+			input:    "## Section Title",
+			contains: []string{"<h2 ", ">Section Title</h2>"},
+		},
+		{
+			name:     "h3 header",
+			input:    "### Subsection",
+			contains: []string{"<h3 ", ">Subsection</h3>"},
+		},
+		{
+			name:     "inline link",
+			input:    "[OpenAI](https://openai.com)",
+			contains: []string{`<a href="https://openai.com">OpenAI</a>`},
+		},
+		{
+			name:     "fenced code block",
+			input:    "```go\nfmt.Println(\"hello\")\n```",
+			contains: []string{"<pre><code", "fmt.Println"},
+			notContains: []string{"```"},
+		},
+		{
+			name:     "inline code",
+			input:    "Use `template.HTML` type",
+			contains: []string{"<code>template.HTML</code>"},
+		},
+		{
+			name:     "unordered list",
+			input:    "- item one\n- item two\n- item three",
+			contains: []string{"<ul>", "<li>item one</li>", "<li>item two</li>", "<li>item three</li>", "</ul>"},
+		},
+		{
+			name:     "ordered list",
+			input:    "1. first\n2. second\n3. third",
+			contains: []string{"<ol>", "<li>first</li>", "<li>second</li>", "</ol>"},
+		},
+		{
+			name:  "table",
+			input: "| Name | Value |\n|------|-------|\n| foo  | bar   |\n| baz  | qux   |",
+			contains: []string{
+				"<table>",
+				"<thead>",
+				"<th>Name</th>",
+				"<th>Value</th>",
+				"<tbody>",
+				"<td>foo</td>",
+				"<td>bar</td>",
+				"<td>baz</td>",
+				"<td>qux</td>",
+				"</table>",
+			},
+		},
+		{
+			name:     "strikethrough (GFM)",
+			input:    "~~deprecated~~",
+			contains: []string{"<del>deprecated</del>"},
+		},
+		{
+			name:  "autolink (GFM)",
+			input: "Visit https://digistratum.com for more.",
+			contains: []string{`href="https://digistratum.com"`},
+		},
+		{
+			name:     "paragraph",
+			input:    "This is a plain paragraph.",
+			contains: []string{"<p>This is a plain paragraph.</p>"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := markdown.Render(tc.input)
+			if err != nil {
+				t.Fatalf("Render() returned unexpected error: %v", err)
+			}
+
+			// Verify the return type is template.HTML (safe/unescaped) —
+			// string() conversion only compiles if result is template.HTML.
+			html := string(result)
+
+			for _, want := range tc.contains {
+				if !strings.Contains(html, want) {
+					t.Errorf("expected output to contain %q\ngot:\n%s", want, html)
+				}
+			}
+
+			for _, bad := range tc.notContains {
+				if strings.Contains(html, bad) {
+					t.Errorf("expected output NOT to contain %q\ngot:\n%s", bad, html)
+				}
+			}
+		})
+	}
+}
+
+// TestRender_EmptyInput ensures empty markdown returns empty/minimal HTML without error.
+func TestRender_EmptyInput(t *testing.T) {
+	result, err := markdown.Render("")
+	if err != nil {
+		t.Fatalf("Render(\"\") returned unexpected error: %v", err)
+	}
+	html := string(result)
+	// Should be empty or just whitespace — no content generated
+	if strings.TrimSpace(html) != "" {
+		t.Logf("Empty input produced non-empty output (acceptable): %q", html)
+	}
+}
+
+// TestMustRender_PanicsOnError verifies MustRender is a convenience wrapper.
+// Since goldmark doesn't typically error, we mainly verify it returns template.HTML.
+func TestMustRender_ReturnsHTML(t *testing.T) {
+	result := markdown.MustRender("# Hello")
+	// string() on template.HTML proves the compile-time type without an explicit declaration.
+	if !strings.Contains(string(result), "<h1") {
+		t.Errorf("MustRender expected <h1> tag, got: %s", string(result))
+	}
+}
+
+// TestRender_ReturnsTemplateHTML verifies the type at compile-time (type assertion in loop above)
+// and ensures it is NOT plain string (would cause double-escaping in html/template).
+func TestRender_TypeIsTemplateHTML(t *testing.T) {
+	result, err := markdown.Render("**bold**")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// template.HTML assignment proves the type — if this compiles, the type is correct.
+	safe := result
+	_ = safe
+}

--- a/go.mod
+++ b/go.mod
@@ -12,4 +12,6 @@ require (
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/yuin/goldmark v1.8.4 // indirect
+	github.com/yuin/goldmark-emoji v1.0.6 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,10 @@ github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCy
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/yuin/goldmark v1.8.4 h1:oat/nd3U6NeQqFEL3xpEJq7d7c86NI+DbSNGAs4xnjA=
+github.com/yuin/goldmark v1.8.4/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
+github.com/yuin/goldmark-emoji v1.0.6 h1:QWfF2FYaXwL74tfGOW5izeiZepUDroDJfWubQI9HTHs=
+github.com/yuin/goldmark-emoji v1.0.6/go.mod h1:ukxJDKFpdFb5x0a5HqbdlcKtebh086iJpI31LTKmWuA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
## Summary

Implements board story #4719 (E.1) — goldmark-based Markdown → HTML renderer for shared use across DigiStratum Go apps.

## Changes
- **New package:** `github.com/DigiStratum/GoLib/Markdown`
- `Render(md string) (template.HTML, error)` — wraps goldmark with GFM extensions (tables, strikethrough, autolinks, task lists), safe HTML, auto heading IDs
- `MustRender(md string) template.HTML` — convenience panic-on-error wrapper  
- Full table-driven test suite: h1/h2/h3 headers, links, fenced code, inline code, unordered/ordered lists, tables, strikethrough, autolinks, paragraphs, empty input

## Why
Fix: agentic output was being dumped as raw markdown strings into HTML views (unformatted). Returns `template.HTML` to prevent double-escaping in Go templates.

## TDD Evidence (RED→GREEN)
- **RED:** `github.com/DigiStratum/GoLib/Markdown: no non-test Go files` (build failed, 0/15 tests)
- **GREEN:** `ok github.com/DigiStratum/GoLib/Markdown — 15/15 PASS`

## Lint
`golangci-lint run ./Markdown/...` → **0 issues**

## Import Path
`github.com/DigiStratum/GoLib/Markdown`

Downstream stories (E.2 onward): import `github.com/DigiStratum/GoLib/Markdown` and call `markdown.Render(mdString)`.